### PR TITLE
Fix not inferring date when defaulting to last price in price list

### DIFF
--- a/app/services/stockUpdate.js
+++ b/app/services/stockUpdate.js
@@ -242,8 +242,12 @@ function getPairForDate(date, priceList) {
 
   //default to the most recent date if none available and
   //it is earlier than this date
-  if (numPairs > 0 && realDate > utils.avDateStringToDate(priceList[numPairs - 1].date)) {
-    return thisPair;
+  if (numPairs > 0) {
+    var lastPair = priceList[numPairs - 1];
+    if (realDate > utils.avDateStringToDate(lastPair.date)) {
+      console.log('No price exists for ' + date + ' , using last of ' + lastPair.date);
+      return {date: date, price: lastPair.price};
+    }
   }
 
   return undefined;
@@ -309,6 +313,8 @@ function updateStocksData(articleData, stockData) {
             var pair = getPairForDate(date, sortedPrices);
             if (pair) {
               filteredPriceHistory[pair.date] = pair.price;
+            } else {
+              console.log('Could not find/infer price for date: ' + date);
             }
           }
 


### PR DESCRIPTION
If the price list retrieved via AlphaVantage includes dates through 3/9, for example, and we have an article for 3/10, we default to the price from 3/9. We were using the correct price from that date, but we were also storing the price with that date, which is more difficult (and not accounted for) but the UI. This change fixes this and infers the date of 3/10 and stores it as such.

Note: The most recent close price does not change on non market days, so storing the price as a "future" date only simplifies usage.