### PR TITLE
Add Button for Deploy to IBM Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the ``Deploy to IBM Cloud`` button **OR** create the services and run locall
 
 ## Deploy to IBM Cloud
 
-Button To be added
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-stock-advisor)
 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 


### PR DESCRIPTION
Note that there is an
[issue](https://github.com/IBM/metrics-collector-service/issues/37)
with the metrics tracker, so this button does not track deploys.